### PR TITLE
Add report generation feature to PAC tool

### DIFF
--- a/Office365.PacUtil.csproj
+++ b/Office365.PacUtil.csproj
@@ -8,14 +8,14 @@
     </Company>
     <Description>Proxy Auto Configuration (PAC) File Utility for Office 365</Description>
     <Copyright>Copyright © 2024</Copyright>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
     <Product>Proxy Auto Configuration (PAC) File Utility for Office 365</Product>
     <Authors>Callon Campbell</Authors>
-    <Version>1.3.0.0</Version>
-    <InformationalVersion>1.3.0.0</InformationalVersion>
-    <FileVersion>1.3.0.0</FileVersion>
+    <Version>1.3.1.0</Version>
+    <InformationalVersion>1.3.1.0</InformationalVersion>
+    <FileVersion>1.3.1.0</FileVersion>
     <PackageReleaseNotes>
-		- Added new '--optimize' command line option
+		- Added new '--report' command line option
 	</PackageReleaseNotes>
     <UserSecretsId>c4395102-6ff0-466f-b2d8-58345cb88860</UserSecretsId>
   </PropertyGroup>

--- a/Options/PacFileOptions.cs
+++ b/Options/PacFileOptions.cs
@@ -20,5 +20,6 @@ namespace Office365.PacUtil.Options
 
         public bool Force { get; set; }
         public bool Optimize { get; set; }
+        public bool Report { get; set; }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -66,6 +66,10 @@ namespace Office365.PacUtil
                 new Option<bool>(new []{"--optimize"}, "Optimizes event entries by moving duplicate URLs and IPs to a common section.")
                 {
                     IsRequired = false,
+                },
+                new Option<bool>(new []{"--report"}, "Generate report of URLs and IPs from generated pacfile.")
+                {
+                    IsRequired = false,
                 }
             };
             commandPacFileUpdate.Handler = CommandHandler.Create<PacFileOptions, IHost, CancellationToken>(PacCommandFileUpdate);
@@ -75,7 +79,6 @@ namespace Office365.PacUtil
             Command commandPacFileStatus = new Command("update-check", "Checks for updates from Microsoft.\nExample:\n   .\\Office365.PacUtil.exe pac-file update-check");
             commandPacFileStatus.Handler = CommandHandler.Create<PacFileOptions, IHost, CancellationToken>(PacCommandStatus);
             commandPacFile.AddCommand(commandPacFileStatus);
-
 
             root.AddCommand(commandPacFile);
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ The intention of the tool is to provide a custom `proxy.pac` template file which
    .\Office365.PacUtil.exe pac-file generate --file "proxy-template.pac" --optimize
    ```
 1. The generated output will be located in your USERS TEMP directory. `C:\Users\{username}\AppData\Local\Temp\PacUtil\proxy.pac`
-
+1. Optionally, you can generate a report of all the URLs and IPs generrated in the pacfile.
+   ```console
+   .\Office365.PacUtil.exe pac-file generate --file "proxy-template.pac" --report
+   ```
 
 
 ### Configuration


### PR DESCRIPTION
- Updated `Office365.PacUtil.csproj` version to 1.3.1.0 and modified release notes.
- Added `Report` property in `PacFileOptions.cs` for report generation support.
- Introduced `--report` command line option in `Program.cs` for report generation.
- Updated `README.md` to document the `--report` option usage.
- Enhanced `PacFileService.cs` with regex support and added `GeneratePacEndpointListOutputAsync` method for report file creation.
- Performed general code refinements for feature integration and code quality maintenance.

#### PR Classification
This pull request introduces a new feature to generate a report of URLs and IPs from the generated PAC file.

#### PR Summary
The update adds a `--report` command line option to generate a detailed report from PAC files, alongside minor version updates and documentation adjustments to reflect this new functionality.
- Updated `Office365.PacUtil.csproj` for version increment to `1.3.1.0` and updated release notes.
- Added a new `Report` property in `PacFileOptions.cs` and integrated the report generation feature in `PacFileService.cs`.
- Introduced the `--report` option in `Program.cs` and updated `README.md` to document the new feature.
