### PR TITLE
Fix

### DIFF
--- a/Services/PacFileService.cs
+++ b/Services/PacFileService.cs
@@ -417,7 +417,8 @@ namespace Office365.PacUtil.Services
             var lines = outputFile.Split(Environment.NewLine);
             foreach (var line in lines)
             {
-                if (line.Contains("shExpMatch(host,") || 
+                if (line.Contains("dnsDomainIs(host,") ||
+                    line.Contains("shExpMatch(host,") || 
                     line.Contains("isInNet(host,") || 
                     line.Contains("isInNet(myIpAddress(),"))
                 {


### PR DESCRIPTION
#### PR Classification
Enhancement to PAC file processing logic.

#### PR Summary
This pull request updates the logic for selecting relevant lines in PAC files to include a broader set of conditions, enhancing compatibility with various PAC file configurations.
- Expanded line selection criteria in `PacFileService.cs` within `Office365.PacUtil.Services` to also include lines containing `dnsDomainIs(host,` in addition to `shExpMatch(host,`.
